### PR TITLE
v.0.1.0-pre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## 0.1.0-pre
+
++ Add `HexGridEditor` to create grids in editor ;
++ Add `Layout.GetHexCorners3(List<Hex> hexes)` to get corners of many tiles as one footprint ;
++ Add `Layout.GetHexCorners3(Hex hex)` to get corners of a tile as `Vector3[]` ;
++ Fix `Hex.Ring` method which was creating too large offsets ; 
+- Rename `Layout.HexCorners` method to `Layout.GetHexCorners` ;
+
+## 0.0.2-pre
+
++ Add `Layout.HexCorners(Hex hex)` to get corners of a tile as `Vector2[]` ;
++ Optimizing `Hex` struct (with `IEquitable<Hex>`) to be retrieved faster by `IEnumerable.FindItem` ;
+ 
+## 0.0.1-pre
+
++ Add `Hex` struct and logics ;

--- a/Editor.meta
+++ b/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b1c8e95a18b6cfb46b182b1937e5b4b3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/HexGridEditor.cs
+++ b/Editor/HexGridEditor.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEditor;
+using UnityEditor.Graphs;
+using UnityEditor.Overlays;
+using UnityEngine.UIElements;
+
+namespace Lignus.HexTile.Editor
+{
+    [Overlay(typeof(SceneView), "HexGrid", true)]
+    public class HexGridEditor : Overlay
+    {
+        public static readonly Color GridColor = new (0.5f, 0.5f, 0.5f);
+        public static readonly Color HexCursorColor = new (231f/255, 76f/255, 60f/255,0.8f);
+        
+        internal IMGUIContainer _imguiContainer { get; private set; }
+
+        private Layout _hexLayout;
+        private Plane _plane;
+        private bool _isDragging = false;
+        private Hex _lastHexClick;
+        private bool _autoName = true;
+        
+        public override VisualElement CreatePanelContent()
+        {
+            _plane = new Plane(Vector3.up, Vector3.zero);
+            
+            _hexLayout = new Layout() {HexOrientation = Orientation.Pointy()};
+            
+            SceneView.duringSceneGui -= OnSceneGUI;
+            SceneView.duringSceneGui += OnSceneGUI;
+
+            this.displayedChanged += OnDisplayChanged;
+            
+            this._imguiContainer = new IMGUIContainer();
+
+            var toggle = new Toggle() {label = "Display", value = true};
+            toggle.RegisterCallback<ChangeEvent<bool>>(OnToggleChanged);
+            this._imguiContainer.Add(toggle);
+            
+            var autoNames = new Toggle() {label = "Auto Names", value = true};
+            autoNames.RegisterCallback<ChangeEvent<bool>>(x => _autoName = x.newValue);
+            this._imguiContainer.Add(autoNames);
+
+            return (VisualElement) this._imguiContainer;
+            
+        }
+
+        private void OnToggleChanged(ChangeEvent<bool> evt) => OnDisplayChanged(evt.newValue);
+
+        private void OnDisplayChanged(bool display)
+        {
+            if (SceneView.lastActiveSceneView is null) return;
+            
+            SceneView.lastActiveSceneView.showGrid = !display;
+            SceneView.duringSceneGui -= OnSceneGUI;
+            if (display)
+            {
+                SceneView.duringSceneGui += OnSceneGUI;
+            }
+        }
+        
+        void OnSceneGUI(SceneView sceneView)
+        {
+            if (SceneView.lastActiveSceneView is null) return;
+            
+            var offset = _hexLayout.WorldPosToHex(sceneView.pivot);
+            var hexes = Generation.Hexagon(offset, 10);
+            Handles.color = GridColor;
+            Handles.zTest = UnityEngine.Rendering.CompareFunction.Less;
+            
+            foreach (Hex hex in hexes)
+            {
+                DrawHexBorder(hex);
+            }
+            
+            Event e = Event.current;
+            Ray ray = HandleUtility.GUIPointToWorldRay(e.mousePosition);
+            if (_plane.Raycast(ray, out float enter))
+            {
+                var position = ray.GetPoint(enter);
+                var cursorHex = _hexLayout.WorldPosToHex(position);
+
+                Debug.Log($"{Selection.activeGameObject} : {e.type}");
+
+                if (e.type == EventType.ExecuteCommand && e.commandName == "ObjectSelectorClosed")
+                {
+                    var obj = EditorGUIUtility.GetObjectPickerObject();
+                    if (obj is not null)
+                    {
+                        var gameObject = PrefabUtility.InstantiatePrefab(obj, Selection.activeTransform) as GameObject;
+                        gameObject.transform.position = _hexLayout.HexToWorldPoint3(_lastHexClick);
+                        if(_autoName)
+                            gameObject.name = $"{gameObject.name} {_lastHexClick}";
+                    }
+                    _isDragging = false;
+                }
+                else if (e.type == EventType.MouseUp && e.button == 1)
+                {
+                    if (!_isDragging)
+                    {
+                        _lastHexClick = cursorHex;
+                        EditorGUIUtility.ShowObjectPicker<GameObject>(
+                            null , 
+                            false, 
+                            "t:prefab", 
+                            1);
+                    }
+                    
+                    _isDragging = false;
+                }
+                else if (e.type == EventType.MouseUp)
+                {
+                    _isDragging = false;
+                }
+                else if (e.type == EventType.MouseDrag && e.button == 0 && !e.alt && !e.functionKey)
+                {
+                    _isDragging = true;
+                    GameObject[] selectedGameObjects = Selection.gameObjects;
+                    if (selectedGameObjects.Length > 0)
+                    {
+                        var go = selectedGameObjects[0];
+                        go.transform.SetPositionAndRotation(
+                            _hexLayout.HexToWorldPoint3(cursorHex),
+                            Quaternion.identity);
+                        if(_autoName)
+                            go.name = $"{PrefabUtility.GetCorrespondingObjectFromSource(go).name} {cursorHex}";
+                        e.Use();
+                    }
+                }
+                
+                if(!_isDragging)
+                {
+                     DrawHex(cursorHex, HexCursorColor);
+                }
+            }
+            
+            HandleUtility.Repaint();
+        }
+
+        private void DrawHexBorder(Hex hex)
+        {
+            var corners = _hexLayout.GetHexCorners3(hex);
+            DrawCorners(corners);
+        }
+
+        private void DrawHex(Hex hex, Color color)
+        {
+            var oldColor = Handles.color;
+            Handles.color = color;
+            
+            var corners = _hexLayout.GetHexCorners3(hex);
+            Handles.DrawAAConvexPolygon(corners);
+            
+            Handles.color = oldColor;
+        }
+
+        private void DrawCorners(Vector3[] corners)
+        {
+            for (int i = 0; i <= corners.Length - 2; ++i)
+            {
+                Handles.DrawLine(corners[i], corners[i+1]);
+            }
+            Handles.DrawLine(corners[^1], corners[0]);
+        }
+    }
+}

--- a/Editor/HexGridEditor.cs.meta
+++ b/Editor/HexGridEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 51518611cd98ed546a7606954f93667a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/com.lignus.hex-tile.Editor.asmdef
+++ b/Editor/com.lignus.hex-tile.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "com.lignus.hex-tile.Editor",
+    "rootNamespace": "Lignus.HexTile.Editor",
+    "references": [
+        "GUID:5ce53cfb1432650419a0eaacfbb81b2c"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Editor/com.lignus.hex-tile.Editor.asmdef.meta
+++ b/Editor/com.lignus.hex-tile.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 342b58585994cf948afb7ead4cc06b24
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Hex.cs
+++ b/Runtime/Hex.cs
@@ -79,7 +79,7 @@ namespace Lignus.HexTile
             if (range == 0) return new List<Hex>{this};
 
             List<Hex> res = new();
-            Hex hex = Neighbor(startDirection) * (int)range;
+            Hex hex = this + NeighborsCoordinates[(int)startDirection] * (int)range;
             int start = clockwise ? NeighborsCoordinates.Length - 1 : 0,
                 end = clockwise ?  -1 : NeighborsCoordinates.Length;
             for (int i = start; i != end; i += clockwise ? -1 : 1)
@@ -134,13 +134,16 @@ namespace Lignus.HexTile
             return hexes;
         }
 
-        public List<Hex> Range(int range) =>
-            Enumerable.Range(-range, 2 * range + 1).SelectMany(
+        public List<Hex> Range(int range)
+        {
+            var self = this;
+            return  Enumerable.Range(-range, 2 * range + 1).SelectMany(
                 x => Enumerable.Range(
                     Math.Max(-range, -x - range),
                     Math.Min(range, -x + range) - Math.Max(-range, -x - range) + 1),
-                (x, y) => new Hex(x, y)
+                (x, y) => new Hex(x + self.q, y + self.r)
             ).ToList();
+        }
 
         public Hex WrapInRange(int radius) => WrapWith(radius, WraparoundMirrors(radius));
 

--- a/Runtime/TileHover.cs
+++ b/Runtime/TileHover.cs
@@ -20,7 +20,7 @@ namespace Lignus.HexTile.Samples
             if (Physics.Raycast(ray, out RaycastHit hitInfo, 1000))
             {
                 var hex = _grid.HexLayout.WorldPosToHex(hitInfo.point);
-                var corners = _grid.HexLayout.HexCorners(hex);
+                var corners = _grid.HexLayout.GetHexCorners(hex);
                 _lineRenderer.SetPositions(corners.Select(corner => new Vector3(corner.x, 0.3f, corner.y)).ToArray());
             }
         }

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
   "name": "com.lignus.hex-tile",
-  "version": "0.0.1",
+  "version": "0.1.0-pre",
   "displayName": "Hex Tile",
   "description": "Custom package to use hex tiles in your project.",
   "unity": "2022.2",
   "unityRelease": "0f1",
-  "documentationUrl": "https://example.com/",
-  "changelogUrl": "https://example.com/changelog.html",
-  "licensesUrl": "https://example.com/licensing.html",
+  "documentationUrl": "https://github.com/DarkRewar/HexTile",
+  "changelogUrl": "https://github.com/DarkRewar/HexTile/blob/master/CHANGELOG.md",
+  "licensesUrl": "https://github.com/DarkRewar/HexTile/blob/master/LICENSE.md",
   "keywords": [
     "hex",
     "tile",
     "tools"
   ],
   "author": {
-    "name": "Rewar",
-    "email": "unity@example.com",
+    "name": "Lignus",
+    "email": "curtis.pelissier@gmail.com",
     "url": "https://github.com/DarkRewar"
   }
 }


### PR DESCRIPTION
+ Add `HexGridEditor` to create grids in editor ;
+ Add `Layout.GetHexCorners3(List<Hex> hexes)` to get corners of many tiles as one footprint ;
+ Add `Layout.GetHexCorners3(Hex hex)` to get corners of a tile as `Vector3[]` ;
+ Fix `Hex.Ring` method which was creating too large offsets ;
- Rename `Layout.HexCorners` method to `Layout.GetHexCorners` ;